### PR TITLE
Change Harvester to use v4 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ results
 _notes
 
 codesniffer.full.xml
+
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@ _notes
 
 codesniffer.full.xml
 
+auth/*.json
+
 vendor/

--- a/README.md
+++ b/README.md
@@ -4,4 +4,123 @@
 [![Code Climate](https://codeclimate.com/github/MITLibraries/mitlib-pull-hours/badges/gpa.svg)](https://codeclimate.com/github/MITLibraries/mitlib-pull-hours)
 [![Issue Count](https://codeclimate.com/github/MITLibraries/mitlib-pull-hours/badges/issue_count.svg)](https://codeclimate.com/github/MITLibraries/mitlib-pull-hours)
 
-This is an experimental plugin that tries to replace our current hours harvesting script (which requires Python and access to the server's command line) with a WordPress plugin that can be run by administrative users.
+This is a WordPress plugin which harvests the contents of a Google Sheet,
+storing it locally in JSON format. This local cache is then read by the user's
+browser in order to display current information about library hours.
+
+This plugin is one part of the MIT Libraries' hours system. The complete
+system is comprise of:
+
+1. The Google Sheet (for data storage)
+2. The Harvester plugin (this repo) which harvests the spreadsheet for local
+   consumption by users' browsers
+3. The Loader system (in [the MITlibraries-Parent theme](https://github.com/MITLibraries/MITlibraries-parent)) which displays
+   hours information on relevant pages
+
+## Deploying this plugin
+
+This plugin is built with Composer, which requires a build step to be run on
+the server in our current configuration.
+
+**Failure to run these steps during a deploy will break WordPress!**
+
+The steps of the deploy are:
+
+1. Shell onto the target server, and check out the desired branch into your
+   deploy directory.
+2. Enable the PHP CLI using `scl enable rh-php72 /bin/bash`.
+3. Ensure that Composer has the latest dependencies installed. **This is the
+   step which, if skipped, will result in WordPress breaking.** The repair
+   process is to go back and run this step, and then deploy again.
+   a. First time deploy: run `composer install` from inside the plugin repo
+   b. When dependencies update: run `composer update` from inside the plugin
+      repo
+4. Optimize the auto-loader by running `composer dumpautoload -o` inside the
+   plugin repo. **If this step is not run, the plugin will disappear from the
+   administrative interace.** The repair process is to re-start the deploy
+   from this step.
+5. Deploy the plugin using the existing script (`/deploy/deploy-plugin.sh`)
+
+## Running the harvester
+
+This plugin adds two things to the admin interface of WordPress:
+
+1. A widget on the admin dashboard, showing the last time the harvester was
+   run, as well as links to the plugin settings and to the hours spreadsheet.
+2. A settings page for site builders to update its configuration and run a new
+   harvest. This page appears under the Settings menu item.
+
+Updating the plugin settings, and running the harvester itself, are both done
+from the settings page. There are fields for the Google spreadsheet key, and
+for the API key that you will use to read the spreadsheet contents.
+
+The Hours spreadsheet key is found in the URL to your spreadsheet. The default
+value for this field is the key used for the MIT Libraries hours, as an
+example.
+
+The API key can be created using the [Google Developers Console](https://console.developers.google.com/). Please check
+the Google documentation for the [Sheets API](https://developers.google.com/sheets/api) for more information on this.
+
+Submitting the settings form (via the "Update hours cache" button) runs the
+harvester. The files will be saved in a directory on your webserver at
+`/app/libhours-buildjson/` - changing this value can be done in the Harvester
+object in this repo, inside the set_properties method.
+
+## Troubleshooting
+
+Here are a list of errors that we've encountered while running this plugin.
+Most of the problems come down to mistakes in the deploy process.
+
+### Problems visible in the browser
+
+#### "There has been a critical error on your website."
+
+If all of WordPress breaks, and all pages display the error message above,
+then the plugin needs to be re-deployed after running `composer install`.
+
+#### Plugin widget has disappeared
+
+The autoloader has not been optimized (step 4 of deploy process). Run
+`composer dumpautoload -o` in the plugin repository, and redeploy.
+
+#### "Sorry, you are not allowed to access this page." when trying to access the settings page
+
+The autoloader has not been optimized (step 4 of deploy process). Run
+`composer dumpautoload -o` in the plugin repository, and redeploy.
+
+### Messages appearing in the error log
+
+The following error log messages may appear:
+
+#### call_user_func_array() expects parameter 1 to be a valid callback
+
+```
+PHP Notice:  Type: ErrorException; Message:
+call_user_func_array() expects parameter 1 to be a valid callback,
+class 'Mitlib\\Pull_Hours_Admin_Widget' not found;
+File: .../wp-includes/class-wp-hook.php; Line: 287
+```
+
+The autoloader has not been optimized (step 4 of deploy process). Run
+`composer dumpautoload -o` in the plugin repository, and redeploy.
+
+#### require() failed to open stream
+
+Messages such as either of the following appear in the Apache error logs:
+
+```
+PHP Fatal error:  require(): Failed opening required
+.../wp-content/plugins/mitlib-pull-hours/vendor/autoload.php in
+.../wp-content/plugins/mitlib-pull-hours/mitlib-pull-hours.php on line 24
+```
+
+or
+
+```
+PHP Warning:  require(.../wp-content/plugins/mitlib-pull-hours/vendor/autoload.php):
+failed to open stream: No such file or directory in
+.../wp-content/plugins/mitlib-pull-hours/mitlib-pull-hours.php on line 24
+```
+
+This is an indication that the plugin was deployed without running `composer
+install`.

--- a/codesniffer.mitlib.xml
+++ b/codesniffer.mitlib.xml
@@ -6,6 +6,9 @@
 	<!-- Set a description for this ruleset. -->
 	<description>A custom set of code standard rules to check for WordPress themes.</description>
 
+	<!-- Exclude the vendor directory from being assessed. -->
+	<exclude-pattern>/vendor/*</exclude-pattern>
+
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">
 		<!-- Exclude non-security sniffs -->

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,21 @@
             "email": "mjbernha@mit.edu"
         }
     ],
-    "require": {},
+    "require": {
+        "google/apiclient": "^2.0"
+    },
     "autoload": {
         "psr-4": {
             "Mitlib\\": "src/"
         }
+    },
+    "scripts": {
+        "post-install-cmd": "Google_Task_Composer::cleanup",
+        "post-update-cmd": "Google_Task_Composer::cleanup"
+    },
+    "extra": {
+        "google/apiclient-services": [
+            "Sheets"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "MITLibraries/mitlib-pull-hours",
+    "name": "mitlibraries/mitlib-pull-hours",
     "description": "A WordPress plugin",
     "type": "wordpress-plugin",
     "license": "GPLv2",
@@ -9,5 +9,10 @@
             "email": "mjbernha@mit.edu"
         }
     ],
-    "require": {}
+    "require": {},
+    "autoload": {
+        "psr-4": {
+            "Mitlib\\": "src/"
+        }
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,852 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "09c2380059a8c63db81f44ec6a8ef2c5",
+    "packages": [
+        {
+            "name": "firebase/php-jwt",
+            "version": "v5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "feb0e820b8436873675fd3aca04f3728eb2185cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/feb0e820b8436873675fd3aca04f3728eb2185cb",
+                "reference": "feb0e820b8436873675fd3aca04f3728eb2185cb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.8 <=9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "time": "2020-03-25T18:49:23+00:00"
+        },
+        {
+            "name": "google/apiclient",
+            "version": "v2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-api-php-client.git",
+                "reference": "48ec94577b51bde415270116118b07a294e07c43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/48ec94577b51bde415270116118b07a294e07c43",
+                "reference": "48ec94577b51bde415270116118b07a294e07c43",
+                "shasum": ""
+            },
+            "require": {
+                "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0",
+                "google/apiclient-services": "~0.13",
+                "google/auth": "^1.10",
+                "guzzlehttp/guzzle": "~5.3.1||~6.0||~7.0",
+                "guzzlehttp/psr7": "^1.2",
+                "monolog/monolog": "^1.17|^2.0",
+                "php": ">=5.4",
+                "phpseclib/phpseclib": "~0.3.10||~2.0"
+            },
+            "require-dev": {
+                "cache/filesystem-adapter": "^0.3.2",
+                "composer/composer": "^1.10",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "phpcompatibility/php-compatibility": "^9.2",
+                "phpunit/phpunit": "^4.8.36|^5.0",
+                "squizlabs/php_codesniffer": "~2.3",
+                "symfony/css-selector": "~2.1",
+                "symfony/dom-crawler": "~2.1"
+            },
+            "suggest": {
+                "cache/filesystem-adapter": "For caching certs and tokens (using Google_Client::setCache)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Google_": "src/"
+                },
+                "classmap": [
+                    "src/Google/Service/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Client library for Google APIs",
+            "homepage": "http://developers.google.com/api-client-library/php",
+            "keywords": [
+                "google"
+            ],
+            "time": "2020-07-23T21:37:43+00:00"
+        },
+        {
+            "name": "google/apiclient-services",
+            "version": "v0.142",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-api-php-client-services.git",
+                "reference": "3baf0a665cd08975314214b075f28765c97282ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/3baf0a665cd08975314214b075f28765c97282ae",
+                "reference": "3baf0a665cd08975314214b075f28765c97282ae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8|^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Google_Service_": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Client library for Google APIs",
+            "homepage": "http://developers.google.com/api-client-library/php",
+            "keywords": [
+                "google"
+            ],
+            "time": "2020-07-28T00:24:58+00:00"
+        },
+        {
+            "name": "google/auth",
+            "version": "v1.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-auth-library-php.git",
+                "reference": "bb959e91bd8ffbd352ab76cbf11d656ce6435088"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/bb959e91bd8ffbd352ab76cbf11d656ce6435088",
+                "reference": "bb959e91bd8ffbd352ab76cbf11d656ce6435088",
+                "shasum": ""
+            },
+            "require": {
+                "firebase/php-jwt": "~2.0|~3.0|~4.0|~5.0",
+                "guzzlehttp/guzzle": "^5.3.1|^6.2.1|^7.0",
+                "guzzlehttp/psr7": "^1.2",
+                "php": ">=5.4",
+                "psr/cache": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "guzzlehttp/promises": "0.1.1|^1.3",
+                "kelvinmo/simplejwt": "^0.2.5",
+                "phpseclib/phpseclib": "^2",
+                "phpunit/phpunit": "^4.8.36|^5.7",
+                "sebastian/comparator": ">=1.2.3",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "suggest": {
+                "phpseclib/phpseclib": "May be used in place of OpenSSL for signing strings or for token management. Please require version ^2."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\Auth\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google Auth Library for PHP",
+            "homepage": "http://github.com/google/google-auth-library-php",
+            "keywords": [
+                "Authentication",
+                "google",
+                "oauth2"
+            ],
+            "time": "2020-07-27T18:33:35+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "2d9d3c186a6637a43193e66b097c50e4451eaab2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/2d9d3c186a6637a43193e66b097c50e4451eaab2",
+                "reference": "2d9d3c186a6637a43193e66b097c50e4451eaab2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.6.1",
+                "php": "^7.2.5",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.0",
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "dev-phpunit8",
+                "phpunit/phpunit": "^8.5.5",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "time": "2020-06-27T10:33:25+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2019-07-01T23:21:34+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "f9eee5cec93dfb313a38b6b288741e84e53f02d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f9eee5cec93dfb313a38b6b288741e84e53f02d5",
+                "reference": "f9eee5cec93dfb313a38b6b288741e84e53f02d5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/log": "^1.0.1"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^6.0",
+                "graylog2/gelf-php": "^1.4.2",
+                "php-amqplib/php-amqplib": "~2.4",
+                "php-console/php-console": "^3.1.3",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "phpspec/prophecy": "^1.6.1",
+                "phpunit/phpunit": "^8.5",
+                "predis/predis": "^1.1",
+                "rollbar/rollbar": "^1.3",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-23T08:41:23+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "2.0.28",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "d1ca58cf33cb21046d702ae3a7b14fdacd9f3260"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d1ca58cf33cb21046d702ae3a7b14fdacd9f3260",
+                "reference": "d1ca58cf33cb21046d702ae3a7b14fdacd9f3260",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phing/phing": "~2.7",
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.0",
+                "sami/sami": "~2.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "suggest": {
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-08T09:08:33+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2020-03-23T09:12:05+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2019-03-08T08:55:37+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
+}

--- a/index.php
+++ b/index.php
@@ -6,6 +6,6 @@
  * @since 0.1.0
  */
 
-namespace mitlib;
+namespace Mitlib;
 
 // Silence is golden.

--- a/mitlib-pull-hours.php
+++ b/mitlib-pull-hours.php
@@ -13,22 +13,18 @@
  * @link https://github.com/MITLibraries/mitlib-pull-hours
  */
 
-namespace mitlib;
+namespace Mitlib;
 
 // Don't call the file directly!
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Include the necesary classes.
-include_once( 'class-pull-hours-admin-widget.php' );
-include_once( 'class-pull-hours-dashboard.php' );
-include_once( 'class-pull-hours-display-widget.php' );
-include_once( 'class-pull-hours-harvester.php' );
-include_once( 'class-pull-hours-settings.php' );
+// Use the Composer autoloader to get all needed classes.
+require plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 // Call the class' init method as part of dashboard setup.
-add_action( 'admin_init', array( 'mitlib\Pull_Hours_Settings', 'init' ) );
-add_action( 'wp_dashboard_setup', array( 'mitlib\Pull_Hours_Admin_Widget', 'init' ) );
-add_action( 'admin_menu', array( 'mitlib\Pull_Hours_Dashboard', 'init' ) );
-add_action( 'widgets_init', array( 'mitlib\Pull_Hours_Display_Widget', 'init' ) );
+add_action( 'admin_init', array( 'Mitlib\Pull_Hours_Settings', 'init' ) );
+add_action( 'wp_dashboard_setup', array( 'Mitlib\Pull_Hours_Admin_Widget', 'init' ) );
+add_action( 'admin_menu', array( 'Mitlib\Pull_Hours_Dashboard', 'init' ) );
+add_action( 'widgets_init', array( 'Mitlib\Pull_Hours_Display_Widget', 'init' ) );

--- a/mitlib-pull-hours.php
+++ b/mitlib-pull-hours.php
@@ -3,7 +3,7 @@
  * Plugin Name:   MITlib Pull Hours
  * Plugin URI:    https://github.com/MITLibraries/mitlib-pull-hours
  * Description:   A WordPress plugin that populates a local JSON cache from a Google Spreadsheet.
- * Version:       0.2.0
+ * Version:       0.3.0
  * Author:        MIT Libraries
  * Author URI:    https://github.com/MITLibraries
  * Licence:       GPL2

--- a/src/class-pull-hours-admin-widget.php
+++ b/src/class-pull-hours-admin-widget.php
@@ -6,7 +6,7 @@
  * @since 0.0.1
  */
 
-namespace mitlib;
+namespace Mitlib;
 
 /**
  * Defines base widget
@@ -33,7 +33,7 @@ class Pull_Hours_Admin_Widget {
 			wp_add_dashboard_widget(
 				self::WID, // A unique slug/ID.
 				'Library hours information', // Visible name for the widget.
-				array( 'mitlib\Pull_Hours_Admin_Widget', 'widget' )  // Callback for the main widget content.
+				array( 'Mitlib\Pull_Hours_Admin_Widget', 'widget' )  // Callback for the main widget content.
 			);
 		}
 	}
@@ -63,6 +63,6 @@ class Pull_Hours_Admin_Widget {
 		}
 
 		// Use the template to render widget output.
-		require_once( 'templates/admin-widget.php' );
+		require_once( plugin_dir_path( __FILE__ ) . '../templates/admin-widget.php' );
 	}
 }

--- a/src/class-pull-hours-dashboard.php
+++ b/src/class-pull-hours-dashboard.php
@@ -71,7 +71,15 @@ class Pull_Hours_Dashboard {
 		// Perform the updates.
 		if ( 'update' == filter_input( INPUT_POST, 'action' ) ) {
 			// Set default values.
+			$google_api_key = '';
 			$spreadsheet_key = '';
+
+			// Read submitted values.
+			if ( filter_input( INPUT_POST, 'google_api_key' ) ) {
+				$google_api_key = sanitize_text_field(
+					wp_unslash( filter_input( INPUT_POST, 'google_api_key' ) )
+				);
+			}
 
 			// Read submitted values.
 			if ( filter_input( INPUT_POST, 'spreadsheet_key' ) ) {
@@ -80,6 +88,7 @@ class Pull_Hours_Dashboard {
 				);
 			}
 
+			update_option( 'google_api_key', $google_api_key );
 			update_option( 'spreadsheet_key', $spreadsheet_key );
 
 			// Perform the harvesting.

--- a/src/class-pull-hours-dashboard.php
+++ b/src/class-pull-hours-dashboard.php
@@ -6,7 +6,7 @@
  * @since 0.0.1
  */
 
-namespace mitlib;
+namespace Mitlib;
 
 /**
  * Defines base widget
@@ -34,7 +34,7 @@ class Pull_Hours_Dashboard {
 				'Library hours',
 				self::PERMS,
 				'mitlib-hours-dashboard',
-				array( 'mitlib\Pull_Hours_Dashboard', 'dashboard' )
+				array( 'Mitlib\Pull_Hours_Dashboard', 'dashboard' )
 			);
 		}
 	}
@@ -58,7 +58,7 @@ class Pull_Hours_Dashboard {
 		}
 
 		// Otherwise, we render the dashboard page.
-		require_once( 'templates/dashboard.php' );
+		require_once( plugin_dir_path( __FILE__ ) . '../templates/dashboard.php' );
 	}
 
 	/**

--- a/src/class-pull-hours-display-widget.php
+++ b/src/class-pull-hours-display-widget.php
@@ -6,7 +6,7 @@
  * @since 0.2.0
  */
 
-namespace mitlib;
+namespace Mitlib;
 
 /**
  * Defines a public-facing widget for displaying hours information
@@ -85,7 +85,7 @@ class Pull_Hours_Display_Widget extends \WP_Widget {
 	 * Registers widget.
 	 */
 	public static function init() {
-		register_widget( 'mitlib\Pull_Hours_Display_Widget' );
+		register_widget( 'Mitlib\Pull_Hours_Display_Widget' );
 	}
 
 	/**
@@ -119,7 +119,7 @@ class Pull_Hours_Display_Widget extends \WP_Widget {
 		if ( $instance['widget_title'] ) {
 			echo wp_kses( $args['before_title'], $allowed ) . esc_html( $instance['widget_title'] ) . wp_kses( $args['after_title'], $allowed );
 		}
-		require( 'templates/display-widget.php' );
+		require( plugin_dir_path( __FILE__ ) . '../templates/display-widget.php' );
 		echo wp_kses( $args['after_widget'], $allowed );
 	}
 

--- a/src/class-pull-hours-harvester.php
+++ b/src/class-pull-hours-harvester.php
@@ -8,6 +8,8 @@
 
 namespace Mitlib;
 
+use GuzzleHttp\Client;
+
 /**
  * Defines base widget
  */
@@ -156,11 +158,18 @@ class Pull_Hours_Harvester {
 	 * information from the Google Sheets API (v4).
 	 *
 	 * @link https://developers.google.com/sheets/api/quickstart/php
+	 * @link https://github.com/googleapis/google-api-php-client#user-content-controlling-http-client-configuration-directly
 	 */
 	private function get_service() {
+		$httpClient = new Client([
+			'headers' => [
+				'referer' => DOMAIN_CURRENT_SITE
+			]
+		]);
 		$client = new \Google_Client();
 		$client->setApplicationName('Library_Hours_Harvester');
 		$client->setDeveloperKey('API_KEY_HERE');
+		$client->setHttpClient($httpClient);
 		$service = new \Google_Service_Sheets( $client );
 		return $service;
 	}

--- a/src/class-pull-hours-harvester.php
+++ b/src/class-pull-hours-harvester.php
@@ -42,6 +42,15 @@ class Pull_Hours_Harvester {
 	public $data_folder = '';
 
 	/**
+	 * The Google API key is a credential used to access the Google Sheets
+	 * API. It should be restricted to only the Sheets API, as well as
+	 * restricted to referals from Libraries domains.
+	 *
+	 * @var string The API key used to connect to the Google Sheets API.
+	 */
+	public $google_api_key = '';
+
+	/**
 	 * The path is the loal file path to the current directory. It is
 	 * populated by the WordPress function plugin_dir_path(), and is necessary
 	 * because relative file paths fail under WordPress.
@@ -167,8 +176,8 @@ class Pull_Hours_Harvester {
 			]
 		]);
 		$client = new \Google_Client();
-		$client->setApplicationName('Library_Hours_Harvester');
-		$client->setDeveloperKey('API_KEY_HERE');
+		$client->setApplicationName('LibraryHoursSheets');
+		$client->setDeveloperKey( $this->google_api_key );
 		$client->setHttpClient($httpClient);
 		$service = new \Google_Service_Sheets( $client );
 		return $service;
@@ -193,6 +202,9 @@ class Pull_Hours_Harvester {
 		// Define timestamp as current time.
 		$this->cache_timestamp = time();
 		update_option( 'cache_timestamp', $this->cache_timestamp );
+
+		// Populate spreadsheet key based on WP option.
+		$this->google_api_key = get_option( 'google_api_key' );
 
 		// Populate spreadsheet key based on WP option.
 		$this->spreadsheet_key = get_option( 'spreadsheet_key' );

--- a/src/class-pull-hours-harvester.php
+++ b/src/class-pull-hours-harvester.php
@@ -78,6 +78,7 @@ class Pull_Hours_Harvester {
 		// This approach is borrowed from the PHP Quickstart at
 		// https://developers.google.com/sheets/api/quickstart/php
 		$api_client = $this->get_client();
+		var_dump( $api_client );
 
 		// Now we build an associate array of the materials that need to be
 		// harvested from Google Sheets. We start with the spreadsheet key,
@@ -177,6 +178,8 @@ class Pull_Hours_Harvester {
 	 */
 	private function get_client() {
 		error_log( 'This will be the start of the v4 API harvester...' );
+		$client = new \Google_Client();
+		return $client;
 	}
 
 	/**

--- a/src/class-pull-hours-harvester.php
+++ b/src/class-pull-hours-harvester.php
@@ -150,14 +150,14 @@ class Pull_Hours_Harvester {
 	/**
 	 * This method iterates over the $array (defined in build_sheet_list) and
 	 * fetches each item (in the $value) and writes it to the filename defined
-	 * by $key.
+	 * by $target (which has been sanitized with dashes).
 	 *
 	 * @param Array $array An associative array of filenames and URLs.
 	 */
 	private function fetch( $service, $array ) {
-		foreach ( $array as $key => $target ) {
+		foreach ( $array as $target ) {
 			$data = $service->spreadsheets_values->get( $this->spreadsheet_key, $target );
-			$filename = sanitize_title_with_dashes( $target ) . '.json';
+			$filename = sanitize_file_name( $target ) . '.json';
 			$this->write( $filename, json_encode( $data['values'] ) );
 		}
 	}

--- a/src/class-pull-hours-harvester.php
+++ b/src/class-pull-hours-harvester.php
@@ -6,7 +6,7 @@
  * @since 0.0.1
  */
 
-namespace mitlib;
+namespace Mitlib;
 
 /**
  * Defines base widget
@@ -72,6 +72,12 @@ class Pull_Hours_Harvester {
 		// This happens by copying the contents of the data/ folder to a
 		// timestamped folder inside the backups/ folder.
 		$this->backup();
+
+		// Now we establish a client that can retrieve information from the
+		// Google Sheets API (v4).
+		// This approach is borrowed from the PHP Quickstart at
+		// https://developers.google.com/sheets/api/quickstart/php
+		$api_client = $this->get_client();
 
 		// Now we build an associate array of the materials that need to be
 		// harvested from Google Sheets. We start with the spreadsheet key,
@@ -161,6 +167,16 @@ class Pull_Hours_Harvester {
 			$data = file_get_contents( $value );
 			$this->write( $key, $data );
 		}
+	}
+
+	/**
+	 * This method establishes a client, with associated token, that can read
+	 * information from the Google Sheets API (v4).
+	 *
+	 * @link https://developers.google.com/sheets/api/quickstart/php
+	 */
+	private function get_client() {
+		error_log( 'This will be the start of the v4 API harvester...' );
 	}
 
 	/**

--- a/src/class-pull-hours-harvester.php
+++ b/src/class-pull-hours-harvester.php
@@ -158,22 +158,10 @@ class Pull_Hours_Harvester {
 	 * @link https://developers.google.com/sheets/api/quickstart/php
 	 */
 	private function get_service() {
-		error_log( 'Defining Google Sheet Service...' );
 		$client = new \Google_Client();
 		$client->setApplicationName('Library_Hours_Harvester');
-		$client->setScopes(\Google_Service_Sheets::SPREADSHEETS_READONLY);
-		$client->setAuthConfig( plugin_dir_path( __FILE__) . '../auth/credentials.json');
-
-		// Load previously authorized token from a file.
-		// It appears that this token need not be valid, it just needs to be present.
-		$token_path = plugin_dir_path( __FILE__ ) . '../auth/token.json';
-		if ( file_exists( $token_path ) ) {
-			$access_token = json_decode( file_get_contents( $token_path ), true );
-			$client->setAccessToken( $access_token );
-		}
-
+		$client->setDeveloperKey('API_KEY_HERE');
 		$service = new \Google_Service_Sheets( $client );
-
 		return $service;
 	}
 

--- a/src/class-pull-hours-settings.php
+++ b/src/class-pull-hours-settings.php
@@ -19,6 +19,7 @@ class Pull_Hours_Settings {
 	public static function init() {
 		// Register the settings used.
 		register_setting( 'mitlib_pull_hours', 'cache_timestamp' );
+		register_setting( 'mitlib_pull_hours', 'google_api_key' );
 		register_setting( 'mitlib_pull_hours', 'spreadsheet_key' );
 
 		add_settings_section(
@@ -41,6 +42,18 @@ class Pull_Hours_Settings {
 		);
 
 		add_settings_field(
+			'google_api_key',
+			'Google Sheets API key',
+			array( 'Mitlib\Pull_Hours_Settings', 'google_api_key_callback' ),
+			'mitlib-hours-dashboard',
+			'mitlib_pull_hours_general',
+			array(
+				'label_for' => 'google_api_key',
+				'class' => 'mitlib_hours_row',
+			)
+		);
+
+		add_settings_field(
 			'cache_timestamp',
 			'Last harvested',
 			array( 'Mitlib\Pull_Hours_Settings', 'timestamp_callback' ),
@@ -58,6 +71,14 @@ class Pull_Hours_Settings {
 	 */
 	public static function general() {
 		echo '';
+	}
+
+	/**
+	 * Field-rendering callback for the Google Spreadsheet key
+	 */
+	public static function google_api_key_callback() {
+		$google_api_key = get_option( 'google_api_key' );
+		require_once( plugin_dir_path( __FILE__ ) . '../templates/forms/google-api-key.php' );
 	}
 
 	/**

--- a/src/class-pull-hours-settings.php
+++ b/src/class-pull-hours-settings.php
@@ -6,7 +6,7 @@
  * @since 0.0.1
  */
 
-namespace mitlib;
+namespace Mitlib;
 
 /**
  * Defines base widget
@@ -24,14 +24,14 @@ class Pull_Hours_Settings {
 		add_settings_section(
 			'mitlib_pull_hours_general',
 			'General settings',
-			array( 'mitlib\Pull_Hours_Settings', 'general' ),
+			array( 'Mitlib\Pull_Hours_Settings', 'general' ),
 			'mitlib-hours-dashboard'
 		);
 
 		add_settings_field(
 			'spreadsheet_key',
 			'Hours spreadsheet key',
-			array( 'mitlib\Pull_Hours_Settings', 'spreadsheet_callback' ),
+			array( 'Mitlib\Pull_Hours_Settings', 'spreadsheet_callback' ),
 			'mitlib-hours-dashboard',
 			'mitlib_pull_hours_general',
 			array(
@@ -43,7 +43,7 @@ class Pull_Hours_Settings {
 		add_settings_field(
 			'cache_timestamp',
 			'Last harvested',
-			array( 'mitlib\Pull_Hours_Settings', 'timestamp_callback' ),
+			array( 'Mitlib\Pull_Hours_Settings', 'timestamp_callback' ),
 			'mitlib-hours-dashboard',
 			'mitlib_pull_hours_general',
 			array(
@@ -65,7 +65,7 @@ class Pull_Hours_Settings {
 	 */
 	public static function spreadsheet_callback() {
 		$spreadsheet_key = get_option( 'spreadsheet_key' );
-		require_once( 'templates/forms/spreadsheet-key.php' );
+		require_once( plugin_dir_path( __FILE__ ) . '../templates/forms/spreadsheet-key.php' );
 	}
 
 	/**
@@ -73,6 +73,6 @@ class Pull_Hours_Settings {
 	 */
 	public static function timestamp_callback() {
 		$cache_timestamp = get_option( 'cache_timestamp' );
-		require_once( 'templates/forms/cache-timestamp.php' );
+		require_once( plugin_dir_path( __FILE__ ) . '../templates/forms/cache-timestamp.php' );
 	}
 }

--- a/templates/forms/google-api-key.php
+++ b/templates/forms/google-api-key.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * The field template for the Google Spreadsheet key
+ *
+ * @package MITlib Pull Hours
+ * @since 0.0.2
+ */
+
+?>
+
+<input
+	type="text"
+	name="<?php echo esc_attr( 'google_api_key' ); ?>"
+	value="<?php echo esc_attr( $google_api_key ); ?>"
+	id="<?php echo esc_attr( 'google_api_key' ); ?>"
+	size="60">
+<p>Please see EngX or InfraEng if you are not sure what this value should be. The current key should be listed on the Libraries' <a href="https://console.developers.google.com/apis/credentials">Google Developer Console</a>.</p>


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This PR will change the Harvester from the v3 to v4 Sheets API. It is still TBD whether this change will also result in a change of shape to the harvested data.

#### Helpful background context (if appropriate)
This change is related to MITLibraries/MITlibraries-parent#327, which updates the Loader step of the hours system to correspond with this change.

When merged, we will be able to empty out (or delete altogether) two other repos:
https://github.com/MITLibraries/libhours-buildjson (directory needed, but nothing else)
https://github.com/MITLibraries/libhours (all these files are either no longer needed, or moved into this theme)

While working on this change, I also ended up spawning another PR, MITLibraries/mitlib-pull-hours#6, to deal with some code quality issues that were flagged in this repo but aren't related to this work. I mention this here to see if there is interest in reviewing that work. The state of that repo would probably need a rebase and merge after this merges.

#### How can a reviewer manually see the effects of these changes?
For now, this branch is in place on the staging server. If you see two input fields on the settings page at `/wp-admin/options-general.php?page=mitlib-hours-dashboard` then you are seeing this branch. The new field is the one for the API key.

When you run the harvester from that screen, you should also see an updated status message that includes the count of how many sheets have been harvested. You should then be able to see the new cache format at `/app/libhours-buildjson/Default-Hours.json`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/ENGX-32

#### Todo:
- [x] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
YES

#### Requires change to deploy process?

**YES**

I've added significant information to the readme with this PR, including a list of all the failure modes I've encountered as a result of skipping steps in the deploy process. It is probably a good idea to run the deploy as part of a review. This would need to be coordinated with UXWS to make sure that we're not interfering with their work.
