### PR TITLE
Uxws 1364 frontpage hours widget

### DIFF
--- a/mitlib-pull-hours.php
+++ b/mitlib-pull-hours.php
@@ -3,7 +3,7 @@
  * Plugin Name:   MITlib Pull Hours
  * Plugin URI:    https://github.com/MITLibraries/mitlib-pull-hours
  * Description:   A WordPress plugin that populates a local JSON cache from a Google Spreadsheet.
- * Version:       0.4.0
+ * Version:       0.6.0
  * Author:        MIT Libraries
  * Author URI:    https://github.com/MITLibraries
  * Licence:       GPL2
@@ -29,3 +29,4 @@ add_action( 'wp_dashboard_setup', array( 'Mitlib\Pull_Hours_Admin_Widget', 'init
 add_action( 'admin_menu', array( 'Mitlib\Pull_Hours_Dashboard', 'init' ) );
 add_action( 'widgets_init', array( 'Mitlib\Pull_Hours_Display_Widget', 'init' ) );
 add_action( 'widgets_init', array( 'Mitlib\Pull_Hours_Display_Widget_Slim', 'init' ) );
+add_action( 'widgets_init', array( 'Mitlib\Pull_Hours_Display_Widget_Frontpage', 'init' ) );

--- a/src/class-pull-hours-display-widget-frontpage.php
+++ b/src/class-pull-hours-display-widget-frontpage.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Class that defines the widget - used on the homepage - that displays all
+ * library locations with today's hours.
+ *
+ * @package MITlib Pull Hours
+ * @since 0.6.0
+ */
+
+namespace Mitlib;
+
+/**
+ * Defines a public-facing widget for displaying all locations
+ */
+class Pull_Hours_Display_Widget_Frontpage extends \WP_Widget {
+
+	/**
+	 * Overridden constructor from WP_Widget.
+	 */
+	public function __construct() {
+		$widget_ops = array(
+			'classname' => 'pull-hours-display-widget-frontpage',
+			'description' => __( 'Locations and hours list for the homepage', 'hoursdisplayfrontpage' ),
+		);
+		parent::__construct(
+			'hoursdisplayfrontpage',
+			__( 'Location Hours - Frontpage', 'hoursdisplayfrontpage' ),
+			$widget_ops
+		);
+	}
+
+	/**
+	 * Widget instance form
+	 *
+	 * @see WP_Widget::form()
+	 *
+	 * @param array $instance Previously saved values from database.
+	 */
+	public function form( $instance ) {
+		$title = $instance['title'];
+
+		$this->form_textfield(
+			'title',
+			'Widget Title:',
+			$title,
+			'The title is not displayed outside of the administration interface.'
+		);
+	}
+
+	/**
+	 * Common template for text fields in widget settings forms.
+	 *
+	 * @param string   $fieldname The name of the field.
+	 * @param string   $fieldtitle The displayed title of the field.
+	 * @param variable $fieldvalue The current value of the field.
+	 * @param string   $fieldexplain Optional: a statement explaining the purpose of the field.
+	 */
+	public function form_textfield( $fieldname, $fieldtitle, $fieldvalue, $fieldexplain = null ) {
+		?>
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( $fieldname ) ); ?>">
+				<?php echo esc_attr( $fieldtitle ); ?>
+				<input
+					class="widefat"
+					id="<?php echo esc_attr( $this->get_field_id( $fieldname ) ); ?>"
+					type="text"
+					name="<?php echo esc_attr( $this->get_field_name( $fieldname ) ); ?>"
+					value="<?php echo esc_html( $fieldvalue ); ?>">
+			</label>
+			<?php
+			if ( $fieldexplain ) {
+				echo esc_html( $fieldexplain );
+			}
+			?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Registers widget.
+	 */
+	public static function init() {
+		register_widget( 'Mitlib\Pull_Hours_Display_Widget_Frontpage' );
+	}
+
+	/**
+	 * Sanitize widget form values as they are saved.
+	 *
+	 * @see WP_Widget::form()
+	 *
+	 * @param array $new_instance Values just sent to be saved.
+	 * @param array $old_instance Previously saved values from database.
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$instance = $old_instance;
+		$instance['title'] = $new_instance['title'];
+		return $instance;
+	}
+
+	/**
+	 * Widget() builds the output
+	 *
+	 * @param array $args See WP_Widget in Developer documentation.
+	 * @param array $instance See WP_Widget in Developer documentation.
+	 * @link https://developer.wordpress.org/reference/classes/wp_widget/
+	 */
+	public function widget( $args, $instance ) {
+		$instance = null; // There are no publicly exposed settings for this widget.
+
+		// Define expected array of tags and attributes in user-configurable fields.
+		$allowed = array(); // Do not allow any tags in these fields.
+
+		// Render markup.
+		echo wp_kses( $args['before_widget'], $allowed );
+		require( plugin_dir_path( __FILE__ ) . '../templates/display-widget-frontpage.php' );
+		echo wp_kses( $args['after_widget'], $allowed );
+	}
+}

--- a/templates/display-widget-frontpage.php
+++ b/templates/display-widget-frontpage.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * The template for the frontpage display widget.
+ *
+ * @package MITlib Pull Hours
+ * @since 0.6.0
+ */
+
+?>
+
+<div class="location">
+	<a href="/barker" aria-labelledby="barker" class="img-loc barker"><span class="sr" id="barker">Barker Library</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/barker">Barker Library</a></h3><div class="hours"><span data-location-hours="Barker Library"></span> today</div><div class="location-info"><a href="/locations/#!barker-library" class="map-location">10-500</a><a href="tel:617-253-0968" class="phone"><span class="number">617-253-0968</span></a></div>
+	</div>
+</div>
+<div class="location">
+	<a href="/dewey" aria-labelledby="dewey" class="img-loc dewey"><span class="sr" id="dewey">Dewey Library</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/dewey">Dewey Library</a></h3><div class="hours"><span data-location-hours="Dewey Library"></span> today</div><div class="location-info"><a href="/locations/#!dewey-library" class="map-location">E53-100</a><a href="tel:617-253-5676" class="phone"><span class="number">617-253-5676</span></a></div>
+	</div>
+</div>
+<div class="location">
+	<a href="/hayden" aria-labelledby="hayden" class="img-loc hayden"><span class="sr" id="hayden">Hayden Library</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours"><span data-location-hours="Hayden Library"></span> today</div> <div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a></div>
+	</div>
+</div>
+<a href="#0" class="show-more hidden-non-mobile">
+	<svg class="icon-arrow-down" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="16.3" height="9.4" viewBox="2.7 8.3 16.3 9.4" enable-background="new 2.7 8.3 16.3 9.4" xml:space="preserve"><path d="M18.982 9.538l-8.159 8.159L2.665 9.538l1.284-1.283 6.875 6.875 6.875-6.875L18.982 9.538z"/></svg>Show 3 More
+</a>
+<div class="location hidden-mobile inactive-mobile">
+	<a href="/rotch" aria-labelledby="rotch" class="img-loc rotch"><span class="sr" id="rotch">Rotch Library</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/rotch">Rotch Library</a></h3><div class="hours"><span data-location-hours="Rotch Library"></span> today</div><div class="location-info"><a href="/locations/#!rotch-library" class="map-location">7-238</a><a href="tel:617-258-5592" class="phone"><span class="number">617-258-5592</span></a></div>
+	</div>
+</div>
+<div class="location hidden-mobile inactive-mobile">
+	<a href="/distinctive-collections" aria-labelledby="dc" class="img-loc archives"><span class="sr" id="dc">Distinctive Collections Reading Room</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/distinctive-collections">Distinctive Collections Reading Room</a></h3><div class="hours"><span data-location-hours="Distinctive Collections"></span> today</div><div class="location-info"><a href="/locations/#!distinctive-collections" class="map-location">14N-118</a><a href="tel:617-253-5690" class="phone"><span class="number">617-253-5690</span></a></div>
+	</div>
+</div>
+<div class="location hidden-mobile inactive-mobile">
+	<a href="/music" aria-labelledby="lewis" class="img-loc lewis"><span class="sr" id="lewis">Lewis Music Library</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/music">Lewis Music Library</a></h3><div class="hours"><span data-location-hours="Lewis Music Library"></span> today</div><div class="location-info"><a href="/locations/#!lewis-music-library" class="map-location">14E-109</a><a href="tel:617-253-5689" class="phone"><span class="number">617-253-5689</span></a></div>
+	</div>
+</div>
+<a href="/hours" class="button-primary--green full add-margin link-hours">All hours &amp; locations</a>


### PR DESCRIPTION
This creates a widget for displaying our primary locations and hours on the sidebar of the front page.

#### Helpful background context (if appropriate)

The template for this widget is taken from the parent theme, at https://github.com/MITLibraries/MITlibraries-parent/blob/main/inc/homepage-hours.php . We are making this into a widget so that we can place user-editable text above and below this display, to more easily update users about our hours and access policies.

#### How can a reviewer manually see the effects of these changes?

This branch has been deployed to the staging site, and the widget put in place.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/uxws-1364

#### Screenshots (if appropriate)

#### Todo:
- [x] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
